### PR TITLE
Add support for `#[serde(with = "...")]` and `#[serde(deserialize_with = "...")]` field attributes

### DIFF
--- a/serde-deserialize-over-derive/src/attr.rs
+++ b/serde-deserialize-over-derive/src/attr.rs
@@ -55,10 +55,25 @@ impl ToTokens for SerdeOption {
 }
 
 impl SerdeOption {
-  fn ident(&self) -> &Ident {
+  pub fn ident(&self) -> &Ident {
     match self {
       Self::Flag(tag) => tag,
       Self::String(opt) => &opt.ident,
+    }
+  }
+
+  pub fn is_flag(&self) -> bool {
+    match self {
+      Self::Flag(_) => true,
+      _ => false,
+    }
+  }
+
+  #[allow(dead_code)]
+  pub fn is_opt(&self) -> bool {
+    match self {
+      Self::String(_) => true,
+      _ => false,
     }
   }
 }
@@ -95,6 +110,7 @@ impl SerdeAttrBody {
     None
   }
 
+  #[allow(dead_code)]
   pub fn span_for(&self, name: &str) -> Span {
     self
       .attrs

--- a/serde-deserialize-over-derive/src/attr.rs
+++ b/serde-deserialize-over-derive/src/attr.rs
@@ -1,0 +1,79 @@
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{Ident, LitStr, Token};
+
+pub(crate) struct ValueOption<T> {
+  pub ident: Ident,
+  #[allow(dead_code)]
+  pub eq: Token![=],
+  pub value: T,
+}
+
+impl<T: Parse> Parse for ValueOption<T> {
+  fn parse(input: ParseStream) -> syn::Result<Self> {
+    Ok(Self {
+      ident: input.parse()?,
+      eq: input.parse()?,
+      value: input.parse()?,
+    })
+  }
+}
+
+pub(crate) enum SerdeOption {
+  Flag(Ident),
+  String(ValueOption<LitStr>),
+}
+
+impl Parse for SerdeOption {
+  fn parse(input: ParseStream) -> syn::Result<Self> {
+    if input.peek2(Token![=]) {
+      input.parse().map(SerdeOption::String)
+    } else {
+      input.parse().map(SerdeOption::Flag)
+    }
+  }
+}
+
+pub(crate) struct SerdeAttrBody {
+  #[allow(dead_code)]
+  pub paren: syn::token::Paren,
+  pub attrs: Punctuated<SerdeOption, Token![,]>,
+}
+
+impl SerdeAttrBody {
+  #[allow(dead_code)]
+  pub fn has(&self, name: &str) -> bool {
+    for attr in &self.attrs {
+      if let SerdeOption::Flag(tag) = attr {
+        if tag.to_string() == name {
+          return true;
+        }
+      }
+    }
+
+    false
+  }
+
+  pub fn get(&self, name: &str) -> Option<&LitStr> {
+    for attr in &self.attrs {
+      if let SerdeOption::String(opt) = attr {
+        if opt.ident.to_string() == name {
+          return Some(&opt.value);
+        }
+      }
+    }
+
+    None
+  }
+}
+
+impl Parse for SerdeAttrBody {
+  fn parse(input: ParseStream) -> syn::Result<Self> {
+    let inner;
+
+    Ok(Self {
+      paren: syn::parenthesized!(inner in input),
+      attrs: Punctuated::parse_terminated(&inner)?,
+    })
+  }
+}

--- a/serde-deserialize-over-derive/src/lib.rs
+++ b/serde-deserialize-over-derive/src/lib.rs
@@ -464,6 +464,7 @@ where
         match &*opt.ident().to_string() {
           "with" => (),
           "deserialize_with" => (),
+          "serialize_with" => (),
           name => {
             return Err(syn::Error::new(
               opt.span(),

--- a/serde-deserialize-over-derive/src/lib.rs
+++ b/serde-deserialize-over-derive/src/lib.rs
@@ -461,6 +461,11 @@ where
         result.deserialize_merge_fn = Some(syn::parse_str(&(lit.value() + "::deserialize_over"))?);
       } else if let Some(lit) = body.get("deserialize_with") {
         result.deserialize_fn = Some(syn::parse_str(&lit.value())?);
+      } else if let Some(_) = body.get("rename") {
+        return Err(syn::Error::new(
+          body.span_for("rename"),
+          r#"#[serde(rename = "...")] is not supported by the DeserializeOver derive macro yet."#,
+        ));
       }
     }
 

--- a/serde-deserialize-over-derive/src/lib.rs
+++ b/serde-deserialize-over-derive/src/lib.rs
@@ -459,6 +459,8 @@ where
       if let Some(lit) = body.get("with") {
         result.deserialize_fn = Some(syn::parse_str(&(lit.value() + "::deserialize"))?);
         result.deserialize_merge_fn = Some(syn::parse_str(&(lit.value() + "::deserialize_over"))?);
+      } else if let Some(lit) = body.get("deserialize_with") {
+        result.deserialize_fn = Some(syn::parse_str(&lit.value())?);
       }
     }
 

--- a/serde-deserialize-over-derive/src/lib.rs
+++ b/serde-deserialize-over-derive/src/lib.rs
@@ -458,7 +458,7 @@ where
 
       if let Some(lit) = body.get("with") {
         result.deserialize_fn = Some(syn::parse_str(&(lit.value() + "::deserialize"))?);
-        result.deserialize_merge_fn = Some(syn::parse_str(&(lit.value() + "::deserialize_merge"))?);
+        result.deserialize_merge_fn = Some(syn::parse_str(&(lit.value() + "::deserialize_over"))?);
       }
     }
 

--- a/serde-deserialize-over/src/lib.rs
+++ b/serde-deserialize-over/src/lib.rs
@@ -110,13 +110,16 @@ mod support;
 
 #[doc(hidden)]
 pub mod export {
-  pub use serde::de::{Error, MapAccess, SeqAccess, Unexpected, Visitor};
+  pub use serde::de::{DeserializeSeed, Error, MapAccess, SeqAccess, Unexpected, Visitor};
   pub use serde::{Deserialize, Deserializer};
 
   pub use std::fmt;
   pub use std::marker::PhantomData;
   pub use std::option::Option::{None, Some};
   pub use std::result::Result::{self, Err, Ok};
+
+  pub use crate::support::{DeserializeOverWrapper, DeserializeWrapper};
+  pub use crate::DeserializeOver;
 }
 
 #[doc(hidden)]

--- a/serde-deserialize-over/src/lib.rs
+++ b/serde-deserialize-over/src/lib.rs
@@ -46,6 +46,8 @@
 //! To mark that subfields should instead be deserialized via
 //! [`DeserializeOver`] the derive macro supports the `#[deserialize_over]`
 //! attribute.
+//! 
+//! # Serde Attributes
 //!
 //! ```
 //! use serde_deserialize_over::DeserializeOver;

--- a/serde-deserialize-over/src/lib.rs
+++ b/serde-deserialize-over/src/lib.rs
@@ -47,8 +47,6 @@
 //! [`DeserializeOver`] the derive macro supports the `#[deserialize_over]`
 //! attribute.
 //!
-//! # Serde Attributes
-//!
 //! ```
 //! use serde_deserialize_over::DeserializeOver;
 //! # use serde_json::Deserializer;
@@ -125,10 +123,9 @@ pub mod export {
   pub use crate::DeserializeOver;
 }
 
-#[doc(hidden)]
-pub use crate::support::DeserializeOverWrapper;
 pub use serde_deserialize_over_derive::DeserializeOver;
 
+use crate::support::DeserializeOverWrapper;
 use serde::Deserializer;
 
 /// Deserialize on top of an existing struct instance.

--- a/serde-deserialize-over/src/lib.rs
+++ b/serde-deserialize-over/src/lib.rs
@@ -46,7 +46,7 @@
 //! To mark that subfields should instead be deserialized via
 //! [`DeserializeOver`] the derive macro supports the `#[deserialize_over]`
 //! attribute.
-//! 
+//!
 //! # Serde Attributes
 //!
 //! ```

--- a/serde-deserialize-over/src/lib.rs
+++ b/serde-deserialize-over/src/lib.rs
@@ -107,6 +107,7 @@
 //! [`Deserializer`]: serde::Deserializer
 
 mod support;
+mod tests;
 
 #[doc(hidden)]
 pub mod export {

--- a/serde-deserialize-over/src/support/mod.rs
+++ b/serde-deserialize-over/src/support/mod.rs
@@ -6,7 +6,7 @@ mod option;
 mod tuple;
 
 use crate::DeserializeOver;
-use serde::de::{DeserializeSeed, Deserializer};
+use serde::de::{DeserializeSeed, Deserializer, Deserialize};
 
 #[doc(hidden)]
 pub struct DeserializeOverWrapper<'a, T>(pub &'a mut T);
@@ -22,5 +22,22 @@ where
     D: Deserializer<'de>,
   {
     self.0.deserialize_over(de)
+  }
+}
+
+pub struct DeserializeWrapper<'a, T>(pub &'a mut T);
+
+impl<'a, 'de, T> DeserializeSeed<'de> for DeserializeWrapper<'a, T>
+where
+  T: Deserialize<'de>
+{
+  type Value = ();
+
+  fn deserialize<D>(self, de: D) -> Result<Self::Value, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    *self.0 = T::deserialize(de)?;
+    Ok(())
   }
 }

--- a/serde-deserialize-over/src/support/mod.rs
+++ b/serde-deserialize-over/src/support/mod.rs
@@ -6,7 +6,7 @@ mod option;
 mod tuple;
 
 use crate::DeserializeOver;
-use serde::de::{DeserializeSeed, Deserializer, Deserialize};
+use serde::de::{Deserialize, DeserializeSeed, Deserializer};
 
 #[doc(hidden)]
 pub struct DeserializeOverWrapper<'a, T>(pub &'a mut T);
@@ -29,7 +29,7 @@ pub struct DeserializeWrapper<'a, T>(pub &'a mut T);
 
 impl<'a, 'de, T> DeserializeSeed<'de> for DeserializeWrapper<'a, T>
 where
-  T: Deserialize<'de>
+  T: Deserialize<'de>,
 {
   type Value = ();
 

--- a/serde-deserialize-over/src/tests.rs
+++ b/serde-deserialize-over/src/tests.rs
@@ -3,11 +3,11 @@
 /// ```compile_fail
 /// use serde_deserialize_over::*;
 /// use serde::*;
-/// 
+///
 /// fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<(), D::Error> {
 ///   Ok(())
 /// }
-/// 
+///
 /// #[derive(DeserializeOver)]
 /// struct BadDeserialize {
 ///   #[deserialize_over]
@@ -20,7 +20,7 @@ mod combo_deserialize_with_and_deserialize_over {}
 /// ```compile_fail
 /// use serde_deserialize_over::*;
 /// use serde::*;
-/// 
+///
 /// #[derive(DeserializeOver)]
 /// struct RenameNotSupported {
 ///   #[serde(rename = "type")]
@@ -28,4 +28,3 @@ mod combo_deserialize_with_and_deserialize_over {}
 /// }
 /// ```
 mod serde_rename_not_supported {}
-

--- a/serde-deserialize-over/src/tests.rs
+++ b/serde-deserialize-over/src/tests.rs
@@ -17,3 +17,15 @@
 /// ```
 mod combo_deserialize_with_and_deserialize_over {}
 
+/// ```compile_fail
+/// use serde_deserialize_over::*;
+/// use serde::*;
+/// 
+/// #[derive(DeserializeOver)]
+/// struct RenameNotSupported {
+///   #[serde(rename = "type")]
+///   ty: ()
+/// }
+/// ```
+mod serde_rename_not_supported {}
+

--- a/serde-deserialize-over/src/tests.rs
+++ b/serde-deserialize-over/src/tests.rs
@@ -1,0 +1,19 @@
+//! This module abuses doctests to create tests that are supposed to fail.
+
+/// ```compile_fail
+/// use serde_deserialize_over::*;
+/// use serde::*;
+/// 
+/// fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<(), D::Error> {
+///   Ok(())
+/// }
+/// 
+/// #[derive(DeserializeOver)]
+/// struct BadDeserialize {
+///   #[deserialize_over]
+///   #[serde(deserialize_with = "deserialize")]
+///   field: ()
+/// }
+/// ```
+mod combo_deserialize_with_and_deserialize_over {}
+

--- a/serde-deserialize-over/tests/derive_deserialize_with.rs
+++ b/serde-deserialize-over/tests/derive_deserialize_with.rs
@@ -1,0 +1,33 @@
+use serde_derive::Deserialize;
+use serde_deserialize_over::DeserializeOver;
+use std::time::Duration;
+
+mod duration {
+  use serde::{Deserialize, Deserializer};
+  use std::time::Duration;
+
+  pub(super) fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Duration, D::Error> {
+    f64::deserialize(de).map(Duration::from_secs_f64)
+  }
+}
+
+#[derive(Deserialize, DeserializeOver)]
+struct WithCustomSerialize {
+  #[serde(deserialize_with = "duration::deserialize")]
+  duration: Duration,
+}
+
+#[test]
+fn works() {
+  let json = r#"{ "duration": 50.0 }"#;
+  let mut instance = WithCustomSerialize {
+    duration: Duration::new(0, 0),
+  };
+  let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new(json));
+
+  instance
+    .deserialize_over(&mut de)
+    .expect("Failed to deserialize");
+
+  assert_eq!(instance.duration, Duration::from_secs(50));
+}

--- a/serde-deserialize-over/tests/derive_with.rs
+++ b/serde-deserialize-over/tests/derive_with.rs
@@ -1,0 +1,33 @@
+use serde_derive::Deserialize;
+use serde_deserialize_over::DeserializeOver;
+use std::time::Duration;
+
+mod duration {
+  use serde::{Deserialize, Deserializer};
+  use std::time::Duration;
+
+  pub(super) fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Duration, D::Error> {
+    f64::deserialize(de).map(Duration::from_secs_f64)
+  }
+}
+
+#[derive(Deserialize, DeserializeOver)]
+struct WithCustomSerialize {
+  #[serde(with = "duration")]
+  duration: Duration,
+}
+
+#[test]
+fn works() {
+  let json = r#"{ "duration": 50.0 }"#;
+  let mut instance = WithCustomSerialize {
+    duration: Duration::new(0, 0),
+  };
+  let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new(json));
+
+  instance
+    .deserialize_over(&mut de)
+    .expect("Failed to deserialize");
+
+  assert_eq!(instance.duration, Duration::from_secs(50));
+}

--- a/serde-deserialize-over/tests/derive_with_merge.rs
+++ b/serde-deserialize-over/tests/derive_with_merge.rs
@@ -1,0 +1,54 @@
+use serde_derive::Deserialize;
+use serde_deserialize_over::DeserializeOver;
+
+mod custom {
+  use super::DeserializeOver;
+  use super::Inner;
+  use serde::Deserializer;
+
+  pub(super) fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Inner, D::Error> {
+    let mut inner = Inner::default();
+    inner.deserialize_over(de)?;
+    Ok(inner)
+  }
+
+  pub(super) fn deserialize_over<'de, D: Deserializer<'de>>(
+    de: D,
+    inner: &mut Inner,
+  ) -> Result<(), D::Error> {
+    inner.b = "bar".to_owned();
+    inner.deserialize_over(de)
+  }
+}
+
+#[derive(Default, DeserializeOver)]
+struct Inner {
+  a: String,
+  b: String,
+}
+
+#[derive(Deserialize, DeserializeOver)]
+struct WithCustomSerialize {
+  #[deserialize_over]
+  #[serde(with = "custom")]
+  inner: Inner,
+}
+
+#[test]
+fn works() {
+  let json = r#"{ "inner": { "a": "test" } }"#;
+  let mut instance = WithCustomSerialize {
+    inner: Inner {
+      a: "blah".to_owned(),
+      b: "foo".to_owned(),
+    },
+  };
+  let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new(json));
+
+  instance
+    .deserialize_over(&mut de)
+    .expect("Failed to deserialize");
+
+  assert_eq!(instance.inner.a, "test");
+  assert_eq!(instance.inner.b, "bar");
+}


### PR DESCRIPTION
This PR implements support for some serde field attributes so that they work with the `DeserializeOver` derive macro. To do this it also does the following:
- Implement a basic parser for all serde option types
- Explicitly check against all serde field options that we support and error out on ones that aren't invalid - this allows for us to add support for more options in a backwards-compatible way.
- Clean up some internals to simplify the derive macro implementation