### PR TITLE
Implement support for `#[serde(rename = "...")]`

### DIFF
--- a/serde-deserialize-over-derive/src/lib.rs
+++ b/serde-deserialize-over-derive/src/lib.rs
@@ -139,7 +139,7 @@ impl FieldInfo {
   fn source_name(&self) -> syn::LitStr {
     match &self.srcname {
       Some(name) => syn::LitStr::new(&name, self.name.span()),
-      None => syn::LitStr::new(&self.name.to_string(), self.name.span())
+      None => syn::LitStr::new(&self.name.to_string(), self.name.span()),
     }
   }
 }
@@ -163,10 +163,7 @@ fn impl_generic(
   let field_enums = &field_enums;
   let field_enums_copy1 = field_enums;
   let field_enums_copy2 = field_enums;
-  let field_names = fields
-    .iter()
-    .map(|x| x.source_name())
-    .collect::<Vec<_>>();
+  let field_names = fields.iter().map(|x| x.source_name()).collect::<Vec<_>>();
   let field_names = &field_names;
   let indices = (0usize..fields.len()).collect::<Vec<_>>();
   let indices_u64 = indices.iter().map(|x| *x as u64);

--- a/serde-deserialize-over/src/tests.rs
+++ b/serde-deserialize-over/src/tests.rs
@@ -16,15 +16,3 @@
 /// }
 /// ```
 mod combo_deserialize_with_and_deserialize_over {}
-
-/// ```compile_fail
-/// use serde_deserialize_over::*;
-/// use serde::*;
-///
-/// #[derive(DeserializeOver)]
-/// struct RenameNotSupported {
-///   #[serde(rename = "type")]
-///   ty: ()
-/// }
-/// ```
-mod serde_rename_not_supported {}

--- a/serde-deserialize-over/tests/derive_multi.rs
+++ b/serde-deserialize-over/tests/derive_multi.rs
@@ -1,0 +1,26 @@
+use serde_deserialize_over::*;
+
+#[derive(DeserializeOver, Default)]
+struct A {
+  b: String,
+}
+
+#[derive(DeserializeOver, Default)]
+struct B {
+  #[deserialize_over]
+  #[serde(rename = "test")]
+  a: A,
+}
+
+#[test]
+fn works() {
+  let json = r#"{ "test": { "b": "AAAAA" } }"#;
+  let mut instance = B::default();
+  let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new(json));
+
+  instance
+    .deserialize_over(&mut de)
+    .expect("Failed to deserialize");
+
+  assert_eq!(instance.a.b, "AAAAA");
+}

--- a/serde-deserialize-over/tests/derive_rename.rs
+++ b/serde-deserialize-over/tests/derive_rename.rs
@@ -1,0 +1,26 @@
+use serde_deserialize_over::DeserializeOver;
+
+#[derive(Default, DeserializeOver, Debug)]
+struct ExampleStruct {
+  #[serde(rename = "type")]
+  pub a: String,
+  pub b: i32,
+}
+
+const JSON: &str = r#"{ "type": "test" }"#;
+
+#[test]
+fn works() {
+  let mut instance = ExampleStruct {
+    a: "a string".to_owned(),
+    b: 64,
+  };
+  let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new(JSON));
+
+  instance
+    .deserialize_over(&mut de)
+    .expect("Failed to deserialize");
+
+  assert_eq!(instance.a, "test");
+  assert_eq!(instance.b, 64);
+}

--- a/serde-deserialize-over/tests/derive_rename.rs
+++ b/serde-deserialize-over/tests/derive_rename.rs
@@ -7,15 +7,14 @@ struct ExampleStruct {
   pub b: i32,
 }
 
-const JSON: &str = r#"{ "type": "test" }"#;
-
 #[test]
 fn works() {
+  let json = r#"{ "type": "test" }"#;
   let mut instance = ExampleStruct {
     a: "a string".to_owned(),
     b: 64,
   };
-  let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new(JSON));
+  let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new(json));
 
   instance
     .deserialize_over(&mut de)
@@ -23,4 +22,20 @@ fn works() {
 
   assert_eq!(instance.a, "test");
   assert_eq!(instance.b, 64);
+}
+
+#[test]
+#[should_panic]
+fn old_field_fails() {
+  let json = r#"{ "a": "test" }"#;
+
+  let mut instance = ExampleStruct {
+    a: "a string".to_owned(),
+    b: 64,
+  };
+  let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new(json));
+
+  instance
+    .deserialize_over(&mut de)
+    .expect("Failed to deserialize");
 }


### PR DESCRIPTION
As in the title. Also includes a couple of test cases verifying that everything works as expected.