### PR TITLE
Add support for more serde attributes

### DIFF
--- a/serde-deserialize-over-derive/src/lib.rs
+++ b/serde-deserialize-over-derive/src/lib.rs
@@ -468,10 +468,10 @@ where
         // Put serde arguments that we support here so that we can error out on
         // unsupported ones.
         match &*opt.ident().to_string() {
-          "with" => (),
-          "deserialize_with" => (),
-          "serialize_with" => (),
+          "with" | "deserialize_with" | "serialize_with" => (),
           "rename" => (),
+          // #[serde(default)] is ignored since we already have values for all fields
+          "default" => (),
           name => {
             return Err(syn::Error::new(
               opt.span(),

--- a/serde-deserialize-over-derive/src/lib.rs
+++ b/serde-deserialize-over-derive/src/lib.rs
@@ -14,7 +14,7 @@ use proc_macro_crate::{crate_name, FoundCrate};
 use quote::{quote, ToTokens};
 use syn::{
   parse_macro_input, parse_quote, punctuated::Punctuated, Attribute, Data, DeriveInput, Fields,
-  FieldsNamed, FieldsUnnamed, GenericParam, Ident, Meta, Path, Token, Type,
+  FieldsNamed, FieldsUnnamed, GenericParam, Ident, Path, Token, Type,
 };
 
 const CRATE_NAME: &str = "serde_deserialize_over";
@@ -523,15 +523,6 @@ where
       if let Some(lit) = body.get("rename") {
         result.rename = Some(lit.clone());
       }
-    }
-
-    match attr.parse_meta()? {
-      Meta::Path(ref path) => {
-        if path.is_ident("deserialize_over") {
-          result.use_deserialize_over = true;
-        }
-      }
-      Meta::List(_) | Meta::NameValue(_) => (),
     }
   }
 

--- a/serde-deserialize-over-derive/src/lib.rs
+++ b/serde-deserialize-over-derive/src/lib.rs
@@ -492,7 +492,10 @@ where
         if !seen.insert(ident) {
           return Err(syn::Error::new_spanned(
             opt,
-            &format!("Option `{}` cannot be specified multiple times", opt.ident()),
+            &format!(
+              "Option `{}` cannot be specified multiple times",
+              opt.ident()
+            ),
           ));
         }
       }
@@ -528,7 +531,7 @@ where
         if result.rename.is_some() {
           return Err(syn::Error::new(
             body.span_for("deserialize"),
-            "Cannot specify both `rename` and `deserialize`"
+            "Cannot specify both `rename` and `deserialize`",
           ));
         }
 

--- a/serde-deserialize-over-derive/src/lib.rs
+++ b/serde-deserialize-over-derive/src/lib.rs
@@ -523,6 +523,17 @@ where
       if let Some(lit) = body.get("rename") {
         result.rename = Some(lit.clone());
       }
+
+      if let Some(lit) = body.get("deserialize") {
+        if result.rename.is_some() {
+          return Err(syn::Error::new(
+            body.span_for("deserialize"),
+            "Cannot specify both `rename` and `deserialize`"
+          ));
+        }
+
+        result.rename = Some(lit.clone());
+      }
     }
   }
 

--- a/serde-deserialize-over/src/tests.rs
+++ b/serde-deserialize-over/src/tests.rs
@@ -20,7 +20,7 @@ mod combo_deserialize_with_and_deserialize_over {}
 /// ```compile_fail
 /// use serde_deserialize_over::*;
 /// use serde::*;
-/// 
+///
 /// #[derive(DeserializeOver)]
 /// struct MultiRename {
 ///   #[serde(rename = "a", deserialize = "b")]
@@ -32,7 +32,7 @@ mod combo_rename_and_deserialize {}
 /// ```compile_fail
 /// use serde_deserialize_over::*;
 /// use serde::*;
-/// 
+///
 /// #[derive(DeserializeOver)]
 /// struct RepeatedOption {
 ///   #[serde(rename = "x", rename = "y")]

--- a/serde-deserialize-over/src/tests.rs
+++ b/serde-deserialize-over/src/tests.rs
@@ -22,6 +22,18 @@ mod combo_deserialize_with_and_deserialize_over {}
 /// use serde::*;
 /// 
 /// #[derive(DeserializeOver)]
+/// struct MultiRename {
+///   #[serde(rename = "a", deserialize = "b")]
+///   field: ()
+/// }
+/// ```
+mod combo_rename_and_deserialize {}
+
+/// ```compile_fail
+/// use serde_deserialize_over::*;
+/// use serde::*;
+/// 
+/// #[derive(DeserializeOver)]
 /// struct RepeatedOption {
 ///   #[serde(rename = "x", rename = "y")]
 ///   field: ()

--- a/serde-deserialize-over/src/tests.rs
+++ b/serde-deserialize-over/src/tests.rs
@@ -16,3 +16,15 @@
 /// }
 /// ```
 mod combo_deserialize_with_and_deserialize_over {}
+
+/// ```compile_fail
+/// use serde_deserialize_over::*;
+/// use serde::*;
+/// 
+/// #[derive(DeserializeOver)]
+/// struct RepeatedOption {
+///   #[serde(rename = "x", rename = "y")]
+///   field: ()
+/// }
+/// ```
+mod duplicate_option {}


### PR DESCRIPTION
This PR adds support for `#[serde(deserialize = "...")]` and `#[serde(default)]`. It also adds an explicit error if any option is specified multiple times.